### PR TITLE
Improved: code to check for instance url value and then setting the base url in config(#2rc2q1e)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -83,8 +83,7 @@ const api = async (customConfig: any) => {
         data: customConfig.data,
         params: customConfig.params
     }
-    const baseURL = instanceUrl;
-    if (baseURL) config.baseURL = `https://${baseURL}.hotwax.io/api/`;
+    if (instanceUrl) config.baseURL = instanceUrl.startsWith('http') ? instanceUrl : `https://${instanceUrl}.hotwax.io/api/`;
 
     if(customConfig.cache) config.adapter = axiosCache.adapter;
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Currently, we were using the instanceURL directly for preparing baseURL for config without checking what value is present in instanceURL.


Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a check that if the instanceURL starts with http, then setting baseURL as is, otherwise preparing the URL for config


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/oms-api/blob/main/CONTRIBUTING.md)