### PR TITLE
Implemented: code to define success response schema(#85zrhhcgr)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { events, Product, Response, Stock, Order, OrderItem, OrderPart, OPERATOR, User } from '@/types'
+import { events, Product, Response, Stock, ListResponse, Order, OrderItem, OrderPart, OPERATOR, User } from '@/types'
 import { init, resetConfig, updateToken, updateInstanceUrl } from '@/api'
 import { isError } from '@/util'
 import { fetchProducts, fetchProductsGroupedBy, fetchProductsGroupedByParent, fetchProductsStockAtFacility, getOrderDetails, getProfile, updateOrderStatus } from '@/modules'
@@ -17,6 +17,7 @@ export {
   fetchProductsStockAtFacility,
   getProfile,
   events,
+  ListResponse,
   Product,
   Response,
   Stock,

--- a/src/modules/product/index.ts
+++ b/src/modules/product/index.ts
@@ -1,10 +1,10 @@
 import api from "@/api";
-import { OPERATOR, Product, Response, SuccessResponse } from "@/types";
+import { OPERATOR, Product, Response, ListResponse } from "@/types";
 import { hasError } from "@/util";
 import { transform } from 'node-json-transform'
 import { productTransformRule } from "@/mappings/product";
 
-async function fetchProducts(params: any): Promise<any | Response> {
+async function fetchProducts(params: any): Promise<ListResponse<Product> | Response> {
 
   const payload = {
     "json": {
@@ -53,15 +53,15 @@ async function fetchProducts(params: any): Promise<any | Response> {
 
       const products: Array<Product> = transform(resp.data.response.docs, productTransformRule)
 
-      response = {
+      return Promise.resolve({
         list: products,
         total: resp.data?.response?.numFound
-      }
+      })
     } else {
-      response = {
+      return Promise.resolve({
         list: [],
         total: 0
-      }
+      })
     }
   } catch (err) {
     return Promise.reject({
@@ -72,7 +72,7 @@ async function fetchProducts(params: any): Promise<any | Response> {
   }
 }
 
-async function fetchProductsGroupedBy(params: any): Promise<any | Response> {
+async function fetchProductsGroupedBy(params: any): Promise<ListResponse<Product> | Response> {
 
   const payload = {
     "json": {
@@ -132,17 +132,17 @@ async function fetchProductsGroupedBy(params: any): Promise<any | Response> {
         }
       })
 
-      return {
-        products,
-        matches: resp.data?.grouped?.groupId.matches,
-        ngroups: resp.data?.grouped?.groupId.ngroups
-      }
+      return Promise.resolve({
+        list: products,
+        total: resp.data?.grouped?.groupId.matches,
+        groups: resp.data?.grouped?.groupId.ngroups
+      })
     } else {
-      return {
-        products: {},
-        matches: 0,
-        ngroups: 0
-      }
+      return Promise.resolve({
+        list: [],
+        total: 0,
+        groups: 0
+      })
     }
   } catch (err) {
     return Promise.reject({
@@ -153,7 +153,7 @@ async function fetchProductsGroupedBy(params: any): Promise<any | Response> {
   }
 }
 
-async function fetchProductsGroupedByParent(params: any): Promise<Product[] | Response> {
+async function fetchProductsGroupedByParent(params: any): Promise<ListResponse<Product> | Response> {
 
   const payload = {
     ...params,

--- a/src/modules/product/index.ts
+++ b/src/modules/product/index.ts
@@ -54,18 +54,14 @@ async function fetchProducts(params: any): Promise<SuccessResponse<Product> | Re
 
       const products: Array<Product> = transform(resp.data.response.docs, productTransformRule)
 
-      return {
+      response = {
         list: products,
-        count: {
-          total: resp.data?.response?.numFound
-        }
+        total: resp.data?.response?.numFound
       }
     } else {
-      return {
+      response = {
         list: [],
-        count: {
-          total: 0
-        }
+        total: 0
       }
     }
   } catch (err) {

--- a/src/modules/product/index.ts
+++ b/src/modules/product/index.ts
@@ -56,12 +56,16 @@ async function fetchProducts(params: any): Promise<SuccessResponse<Product> | Re
 
       return {
         list: products,
-        total: resp.data?.response?.numFound
+        count: {
+          total: resp.data?.response?.numFound
+        }
       }
     } else {
       return {
         list: [],
-        total: 0
+        count: {
+          total: 0
+        }
       }
     }
   } catch (err) {

--- a/src/modules/product/index.ts
+++ b/src/modules/product/index.ts
@@ -1,11 +1,11 @@
 import api from "@/api";
-import { OPERATOR, Product, Response } from "@/types";
-import { hasError, isError } from "@/util";
+import { OPERATOR, Product, Response, SuccessResponse } from "@/types";
+import { hasError } from "@/util";
 import { transform } from 'node-json-transform'
 import { productTransformRule } from "@/mappings/product";
 
-async function fetchProducts(params: any): Promise<any | Response> {
-  let response = {} as Product[] | Response
+async function fetchProducts(params: any): Promise<SuccessResponse<Product> | Response> {
+  let response: SuccessResponse<Product> | Response
 
   const payload = {
     "json": {
@@ -52,15 +52,15 @@ async function fetchProducts(params: any): Promise<any | Response> {
 
     if (resp.status == 200 && !hasError(resp) && resp.data?.response?.numFound > 0) {
 
-      const product: Array<Product> = transform(resp.data.response.docs, productTransformRule)
+      const products: Array<Product> = transform(resp.data.response.docs, productTransformRule)
 
       return {
-        products: product,
+        list: products,
         total: resp.data?.response?.numFound
       }
     } else {
       return {
-        products: {},
+        list: [],
         total: 0
       }
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,23 +41,8 @@ interface Response {
 
 interface SuccessResponse<Type> {
   list: Type[];
-  count: {
-    [x: string]: number;
-  }
-}
-
-interface ResponseCount {
-  total?: number;
-  matches?: number;
-  ngroups?: number;
-}
-
-interface ProductResponse extends ResponseCount{
-  products: Product[]
-}
-
-interface OrderResponse extends ResponseCount{
-  orders: Order[]
+  total: number;
+  groups?: number;
 }
 
 export {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,20 @@ interface SuccessResponse<Type> {
   }
 }
 
+interface ResponseCount {
+  total?: number;
+  matches?: number;
+  ngroups?: number;
+}
+
+interface ProductResponse extends ResponseCount{
+  products: Product[]
+}
+
+interface OrderResponse extends ResponseCount{
+  orders: Order[]
+}
+
 export {
   ContactMech,
   Enumeration,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,11 @@ interface Response {
   serverResponse?: any;
 }
 
+interface SuccessResponse<Type> {
+  list: Type[];
+  total: number;
+}
+
 export {
   ContactMech,
   Enumeration,
@@ -53,5 +58,6 @@ export {
   Uom,
   User,
   Response,
+  SuccessResponse,
   events
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,7 +41,9 @@ interface Response {
 
 interface SuccessResponse<Type> {
   list: Type[];
-  total: number;
+  count: {
+    [x: string]: number;
+  }
 }
 
 export {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,7 +40,7 @@ interface Response {
   serverResponse?: any;
 }
 
-interface SuccessResponse<T> {
+interface ListResponse<T> {
   list: Array<T>;
   total?: number;
   groups?: number;
@@ -51,6 +51,7 @@ export {
   Enumeration,
   events,
   Geo,
+  ListResponse,
   Order,
   OrderItem,
   OrderPart,
@@ -61,6 +62,5 @@ export {
   Status,
   Stock,
   Uom,
-  SuccessResponse,
   User
 }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #38 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added two different approaches for defining schema

1. ) Using Generics:

Defined an interface using generics, so as the same can be directly used for different type of success responses. Also added another property as object `count` that contains indexable types to contains different types of count like total (for total number of products), matches (in case when we are fetching resps as groups).

2.) By extending interface

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/oms-api/blob/main/CONTRIBUTING.md)