### PR TITLE
Implemented: Added format parameter to support 'markdown' responses in API(#96)

### DIFF
--- a/src/modules/gitbook/index.ts
+++ b/src/modules/gitbook/index.ts
@@ -8,7 +8,10 @@ async function askQuery(payload: any): Promise<any> {
       method: "post",
       baseURL: payload.baseURL,
       data: {
-        "query": payload.queryString
+        "query": payload.queryString,
+      },
+      params: {
+        "format": "markdown"
       },
       headers: {
         Authorization:  'Bearer ' + payload.token,


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#96 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This update introduces a new parameter to the Ask Query oms-api, allowing users to specify a response format using the 'format' key. Supported values include 'document' and 'markdown', enabling the API to return responses in the respective format.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/oms-api/blob/main/CONTRIBUTING.md)