### PR TITLE
Improved: Added `productIdentifierEnumId` to the fieldList while fetching the product store by facility or without facility

### DIFF
--- a/src/modules/user/index.ts
+++ b/src/modules/user/index.ts
@@ -378,7 +378,7 @@ async function getEComStoresByFacility(token: any, baseURL: string, vSize = 100,
       ...filters
     },
     "viewSize": vSize,
-    "fieldList": ["productStoreId", "storeName"],
+    "fieldList": ["productStoreId", "storeName", "productIdentifierEnumId"],
     "entityName": "ProductStoreFacilityDetail",
     "distinct": "Y",
     "noConditionFind": "Y",
@@ -413,7 +413,7 @@ async function getEComStoresByFacility(token: any, baseURL: string, vSize = 100,
 async function getEComStores(token: any, baseURL: string, vSize = 100): Promise<any> {
   const params = {
     "viewSize": vSize,
-    "fieldList": ["productStoreId", "storeName"],
+    "fieldList": ["productStoreId", "storeName", "productIdentifierEnumId"],
     "entityName": "ProductStore",
     "distinct": "Y",
     "noConditionFind": "Y"


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added the `productIdentifierEnumId` (store global identifier) field to the `fieldList` in he API for fetching the product store by facility or without facility.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/oms-api/blob/main/CONTRIBUTING.md)