### PR TITLE
Implemented : Generic enum for different Colors for Approved, Completed, Cancelled etc and all the types of status (#672)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotwax/oms-api",
-  "version": "1.22.0",
+  "version": "1.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotwax/oms-api",
-      "version": "1.22.0",
+      "version": "1.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node-json-transform": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotwax/oms-api",
-  "version": "1.22.0",
+  "version": "1.27.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,7 +39,6 @@ enum STATUSCOLOR {
   ITEM_CANCELLED = "danger",
   ITEM_CREATED = "medium",
   ITEM_COMPLETED = "success",
-  ITEM_EXPIRED = "danger",
   ITEM_PENDING_FULFILL = "warning",
   ITEM_PENDING_RECEIPT = "warning",
   ITEM_REJECTED = "danger",
@@ -67,9 +66,7 @@ enum STATUSCOLOR {
   SHIPMENT_APPROVED = "success",
   SHIPMENT_CANCELLED = "danger",
   SHIPMENT_INPUT = "medium",
-  SHIPMENT_IN_TRANSIT = "warning",
   SHIPMENT_PACKED = "success",
-  SHIPMENT_PICKED = "success",
   SHIPMENT_SHIPPED = "success",
 }
 


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #Fulfillment - https://github.com/hotwax/fulfillment/issues/672

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Added an enum for all status types (order, shipment, order-item, payment, etc.), which can be used across various apps. We just need to pass the statusId (e.g., STATUSCOLOR[statusId]), and the corresponding color will be selected automatically. The colors are defined in a consistent way — for example, if a status is Approved, it will always be green across all apps where this enum is used.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/oms-api/blob/main/CONTRIBUTING.md)